### PR TITLE
header授权字段名可配置

### DIFF
--- a/publish/auth.php
+++ b/publish/auth.php
@@ -39,6 +39,12 @@ return [
 
             /*
              * 可选配置
+             * jwt 默认头部token使用的字段
+             */
+            'header_name' => 'Authorization',
+
+            /*
+             * 可选配置
              * jwt 生命周期，单位分钟
              */
             'ttl' => (int) env('SIMPLE_JWT_TTL', 60 * 60),

--- a/publish/auth.php
+++ b/publish/auth.php
@@ -41,7 +41,7 @@ return [
              * 可选配置
              * jwt 默认头部token使用的字段
              */
-            'header_name' => 'Authorization',
+            'header_name' => env('JWT_HEADER_NAME', 'Authorization'),
 
             /*
              * 可选配置

--- a/src/Guard/JwtGuard.php
+++ b/src/Guard/JwtGuard.php
@@ -33,6 +33,8 @@ class JwtGuard extends AbstractAuthGuard
      */
     protected $request;
 
+    protected $headerName = 'Authorization';
+    
     /**
      * JwtGuardAbstract constructor.
      */
@@ -43,13 +45,14 @@ class JwtGuard extends AbstractAuthGuard
         RequestInterface $request
     ) {
         parent::__construct($config, $name, $userProvider);
+        $this->headerName = $config['header_name'] ?? 'Authorization';
         $this->jwtManager = new JWTManager($config);
         $this->request = $request;
     }
 
     public function parseToken()
     {
-        $header = $this->request->header('Authorization', '');
+        $header = $this->request->header($this->headerName, '');
         if (Str::startsWith($header, 'Bearer ')) {
             return Str::substr($header, 7);
         }


### PR DESCRIPTION
现在项目中的名字是固定大写开头的，很多情况下vue前端会把请求头信息全部转换成小写，或者有些项目不是用的Authorization，就无法使用，为了这个名字而自定义Guard的话又比较麻烦，所以做成配置项比较合理。