### PR TITLE
clean up error handler

### DIFF
--- a/src/AuthExceptionHandler.php
+++ b/src/AuthExceptionHandler.php
@@ -21,13 +21,8 @@ class AuthExceptionHandler extends ExceptionHandler
 {
     public function handle(Throwable $throwable, ResponseInterface $response)
     {
-        if ($throwable instanceof UnauthorizedException) {
-            $this->stopPropagation();
-            return $response->withStatus($throwable->getStatusCode())->withBody(new SwooleStream('Unauthorized.'));
-        }
-
-        // 交给下一个异常处理器
-        return $response;
+        $this->stopPropagation();
+        return $response->withStatus($throwable->getStatusCode())->withBody(new SwooleStream('Unauthorized.'));
     }
 
     public function isValid(Throwable $throwable): bool


### PR DESCRIPTION
This is to clean up the error handler class following a similar implementation in class [\Hyperf\HttpServer\Exception\Handler\HttpExceptionHandler](https://github.com/hyperf/hyperf/blob/v2.0.0/src/http-server/src/Exception/Handler/HttpExceptionHandler.php#L44).